### PR TITLE
stops container process if unable to update myriad-kv on load

### DIFF
--- a/engines/docker.js
+++ b/engines/docker.js
@@ -436,6 +436,7 @@ var commands = {
                     if(err){
                         core.loggers["containership.scheduler"].log("warn", ["Failed to load", options.application_name, "container:", options.id].join(" "));
                         core.loggers["containership.scheduler"].log("warn", err.message);
+                        containers[options.id].stop();
                     }
                 });
             });


### PR DESCRIPTION
if unable to write update to myriad-kv, remove the newly created container to prevent untracked containers and allow future deployments to successfully occur