### PR TITLE
Added start/stop logs for applications.

### DIFF
--- a/engines/docker.js
+++ b/engines/docker.js
@@ -215,6 +215,7 @@ module.exports = {
                                         args: args,
                                         uid: container_id,
                                         killSignal: "SIGTERM",
+                                        append: true,
                                         outFile: [base_log_dir, "stdout"].join("/"),
                                         errFile: [base_log_dir, "stderr"].join("/")
                                     });
@@ -426,6 +427,7 @@ var commands = {
                 args: args,
                 uid: options.id,
                 killSignal: "SIGTERM",
+                append: true,
                 outFile: [base_log_dir, "stdout"].join("/"),
                 errFile: [base_log_dir, "stderr"].join("/")
             });

--- a/lib/follower.js
+++ b/lib/follower.js
@@ -1,6 +1,27 @@
 var _ = require("lodash");
 var async = require("async");
 var engines = require([__dirname, "..", "engines"].join("/"));
+var fs = require("fs");
+var mkdirp = require("mkdirp");
+
+function logToContainer(core, containerOptions, mesg) {
+    const basePath = _.get(containerOptions, ["env_vars", "CSHIP_LOG_PATH"], "/var/log/containership");
+    const directory = _.join([basePath, "applications", "containership-logs", containerOptions.id], "/");
+
+    mkdirp(directory, (err) => {
+        if(err) {
+            core.loggers["containership.scheduler"].log("error", "Error creating application log directory: " + err);
+        } else {
+            const path = _.join([directory, "stdout"], "/");
+
+            fs.appendFile(path, mesg + "\n", (err) => {
+                if(err) {
+                    core.loggers["containership.scheduler"].log("error", "Error logging to container: " + err);
+                }
+            });
+        }
+    });
+}
 
 module.exports = function(core){
 
@@ -116,9 +137,10 @@ module.exports = function(core){
                 var container = configuration.container;
                 container.application_name = configuration.application;
 
-                if(_.has(container, "engine") && _.has(engines, container.engine))
+                if(_.has(container, "engine") && _.has(engines, container.engine)) {
                     engines[container.engine].start(container);
-                else{
+                    logToContainer(core, container, _.join(["Starting application", container.application_name, "on container", container.id], " "));
+                } else {
                     var error = new Error("Unsupported engine provided");
                     error.details = ["Engine", container.engine, "not found!"].join(" ");
                     core.loggers["containership.scheduler"].log("error", error.details);
@@ -135,6 +157,7 @@ module.exports = function(core){
 
             stop: function(configuration){
                 engines[configuration.engine].stop(configuration);
+                logToContainer(core, configuration, _.join(["Stopping application:", configuration.application_name, "on container", container.id], " "));
             },
 
             reconcile: function(leader){


### PR DESCRIPTION
So, there's a few places were this logging could be done:

1. In the follower when the container engine's start() and stop() are called
2. Listening on the process that the forever.monitor spins up to execute the docker container.
3. Listening on the dockerode container itself.

I opted for option 1 because it was simple to implement and will apply to future engines automatically should we ever decide to implement any.  If anyone thinks that 2 or 3 are more appropriate, let me know and I'll update this PR accordingly.  