### PR TITLE
Added code to disable docker logs.

### DIFF
--- a/executors/docker
+++ b/executors/docker
@@ -39,6 +39,10 @@ nomnom.command("start").options({
     },
     "HostConfig.Privileged": {
         required: true
+    },
+    "HostConfig.LogConfig.Type": {
+        required: false,
+        default: 'none'
     }
 }).callback(function(options){
     var opts = flat.unflatten(options);


### PR DESCRIPTION
If I'm reading the api documentation correctly, this should disable the container logs.

@nicktate 