### PR TITLE
Disable logs

### DIFF
--- a/executors/docker
+++ b/executors/docker
@@ -78,7 +78,7 @@ nomnom.command("start").options({
             container.start({}, function(err, data){
                 var cleanup = get_cleanup(container);
                 process.on("SIGTERM", cleanup);
-                container.logs({follow: true, stdout: true, stderr: true}, function(err, stream){
+                container.attach({follow: true, stdout: true, stderr: true}, function(err, stream){
                     if(err) {
                         return process.stderr.write(err.message + "\n");
                     }
@@ -99,7 +99,7 @@ nomnom.command("wait").options({
     var container = docker.getContainer(options.container);
     var cleanup = get_cleanup(container);
     process.on("SIGTERM", cleanup);
-    container.logs({follow: true, stdout: true, stderr: true}, function(err, stream){
+    container.attach({follow: true, stdout: true, stderr: true}, function(err, stream){
         if(err) {
             return process.stderr.write(err.message + "\n");
         }

--- a/executors/docker
+++ b/executors/docker
@@ -39,6 +39,10 @@ nomnom.command("start").options({
     },
     "HostConfig.Privileged": {
         required: true
+    },
+    "HostConfig.LogConfig.Type": {
+        required: false,
+        default: 'none'
     }
 }).callback(function(options){
     var opts = flat.unflatten(options);

--- a/executors/docker
+++ b/executors/docker
@@ -78,7 +78,7 @@ nomnom.command("start").options({
             container.start({}, function(err, data){
                 var cleanup = get_cleanup(container);
                 process.on("SIGTERM", cleanup);
-                container.attach({follow: true, stdout: true, stderr: true}, function(err, stream){
+                container.attach({stream:true, stdout: true, stderr: true}, function(err, stream){
                     if(err) {
                         return process.stderr.write(err.message + "\n");
                     }
@@ -99,7 +99,7 @@ nomnom.command("wait").options({
     var container = docker.getContainer(options.container);
     var cleanup = get_cleanup(container);
     process.on("SIGTERM", cleanup);
-    container.attach({follow: true, stdout: true, stderr: true}, function(err, stream){
+    container.attach({stream: true, stdout: true, stderr: true}, function(err, stream){
         if(err) {
             return process.stderr.write(err.message + "\n");
         }


### PR DESCRIPTION
@normanjoyner - changing the logs call in the executor to attach avoids the error you were seeing and seems to behave as intended.

cc @nicktate 